### PR TITLE
Refactor: useInfiniteScroll hook 관심사 분리 -> useWikiListPageState hook 추가

### DIFF
--- a/src/hooks/useInfiniteScroll.tsx
+++ b/src/hooks/useInfiniteScroll.tsx
@@ -1,30 +1,14 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { getProfiles } from "@/api/profile";
-import { Profile } from "@/types/types";
+import { useEffect, useRef } from "react";
 
-const useInfiniteScroll = (initialPage: number, initialList: Profile[]) => {
-  const [list, setList] = useState<Profile[]>(initialList);
-  const [page, setPage] = useState(initialPage);
-  const [hasMore, setHasMore] = useState(true);
+const useInfiniteScroll = (loadMore: () => Promise<void>, hasMore: boolean) => {
   const loadingRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const currentRef = loadingRef.current;
 
-    const loadMoreProfiles = async () => {
-      const newProfiles = await getProfiles({ page: page + 1, pageSize: 12 });
-
-      if (newProfiles.length === 0) {
-        setHasMore(false);
-      } else {
-        setList((prev) => [...prev, ...newProfiles]);
-        setPage((prev) => prev + 1);
-      }
-    };
-
     const observer = new IntersectionObserver((entries) => {
       if (entries[0].isIntersecting && hasMore) {
-        loadMoreProfiles();
+        loadMore();
       }
     });
 
@@ -37,9 +21,9 @@ const useInfiniteScroll = (initialPage: number, initialList: Profile[]) => {
         observer.unobserve(currentRef);
       }
     };
-  }, []);
+  }, [loadMore, hasMore]);
 
-  return { loadingRef, hasMore, list };
+  return loadingRef;
 };
 
 export default useInfiniteScroll;

--- a/src/hooks/useWikiListPageState.ts
+++ b/src/hooks/useWikiListPageState.ts
@@ -1,0 +1,24 @@
+import { useState } from "react";
+import { getProfiles } from "@/api/profile";
+import { Profile } from "@/types/types";
+
+const useWikiListPageState = (initialList: Profile[]) => {
+  const [list, setList] = useState<Profile[]>(initialList);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+
+  const loadMoreProfiles = async () => {
+    const res = await getProfiles({ page: page + 1, pageSize: 12 });
+
+    if (res.data.length === 0) {
+      setHasMore(false);
+    } else {
+      setList((prev) => [...prev, ...res.data]);
+      setPage((prev) => prev + 1);
+    }
+  };
+
+  return { list, loadMoreProfiles, hasMore };
+};
+
+export default useWikiListPageState;

--- a/src/hooks/useWikiListPageState.ts
+++ b/src/hooks/useWikiListPageState.ts
@@ -10,10 +10,10 @@ const useWikiListPageState = (initialList: Profile[]) => {
   const loadMoreProfiles = async () => {
     const res = await getProfiles({ page: page + 1, pageSize: 12 });
 
-    if (res.data.length === 0) {
+    if (res.length === 0) {
       setHasMore(false);
     } else {
-      setList((prev) => [...prev, ...res.data]);
+      setList((prev) => [...prev, ...res]);
       setPage((prev) => prev + 1);
     }
   };

--- a/src/pages/wikilist/index.tsx
+++ b/src/pages/wikilist/index.tsx
@@ -4,6 +4,7 @@ import WikiListTitle from "@/components/WikiListTitle";
 import WikiCardList from "@/components/WikiCardList";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import useInfiniteScroll from "@/hooks/useInfiniteScroll";
+import useWikiListPageState from "@/hooks/useWikiListPageState";
 
 interface WikiListPageProps {
   initialList: Profile[];
@@ -19,7 +20,8 @@ export const getServerSideProps = async () => {
 };
 
 const WikiListPage = ({ initialList }: WikiListPageProps) => {
-  const { loadingRef, hasMore, list } = useInfiniteScroll(1, initialList);
+  const { list, loadMoreProfiles, hasMore } = useWikiListPageState(initialList);
+  const loadingRef = useInfiniteScroll(loadMoreProfiles, hasMore);
 
   return (
     <div className="mx-auto px-[20px] Mobile:px-[100px] Tablet:px-[60px] w-full max-w-[840px] h-full">


### PR DESCRIPTION
## 작업 설명
- wikiList 페이지가 필요로 하는 상태관리는(list, page, hasmore)은 useWikiListPageState이 맡습니다.
- 무한스크롤이 걸렸을 때 list를 업데이트하는 관심사는 useInfiniteScroll이 맡습니다.
- 이렇게 하나의 함수에 하나의 책임만 지게 함으로써 함수의 예측가능성도 높이고, 가독성도 증가시키며, 전반적으로 유지보수성을 개선합니다.

## preview
```typescript
import { getProfiles } from "@/api/profile";
import { Profile } from "@/types/types";
import WikiListTitle from "@/components/WikiListTitle";
import WikiCardList from "@/components/WikiCardList";
import LoadingSpinner from "@/components/LoadingSpinner";
import useInfiniteScroll from "@/hooks/useInfiniteScroll";
import useWikiListPageState from "@/hooks/useWikiListPageState";

interface WikiListPageProps {
  initialList: Profile[];
}

export const getServerSideProps = async () => {
  const res = await getProfiles({ pageSize: 12 });
  return {
    props: {
      initialList: res,
    },
  };
};

const WikiListPage = ({ initialList }: WikiListPageProps) => {
  const { list, loadMoreProfiles, hasMore } = useWikiListPageState(initialList);
  const loadingRef = useInfiniteScroll(loadMoreProfiles, hasMore);

  return (
    <div className="mx-auto px-[20px] Mobile:px-[100px] Tablet:px-[60px] w-full max-w-[840px] h-full">
      <WikiListTitle />
      <WikiCardList list={list} />
      {hasMore && (
        <div ref={loadingRef}>
          <LoadingSpinner />
        </div>
      )}
    </div>
  );
};

export default WikiListPage;


```