### PR TITLE
214/refactor/에러핸들링 개선

### DIFF
--- a/src/api/article.ts
+++ b/src/api/article.ts
@@ -1,5 +1,7 @@
 import { AxiosError } from "axios";
 import instance, { proxy } from "./axios";
+import handleError from "@/api/handleError";
+import handleSuccess from "@/api/handleSuccess";
 
 interface postArticleProps {
   image: string;
@@ -31,67 +33,71 @@ export const getArticles = async (query: getArticlesProps) => {
 
   try {
     const res = await instance.get(`/articles${queryString}`);
-    return res.data;
+    return handleSuccess(res, "게시글 목록 조회에 성공했습니다.");
   } catch (err) {
-    console.error("게시글 목록을 조회하는데 실패했습니다.", err);
-    return {};
+    return handleError(err as AxiosError);
   }
 };
 
 // 게시글 등록
 export const postArticle = async (body: postArticleProps) => {
-  const res = await proxy.post(`/api/articles/`, body);
-  if (res.status >= 200 && res.status < 300) return res.data;
-  else return {};
+  try {
+    const res = await proxy.post(`/api/articles/`, body);
+    return handleSuccess(res, "게시글 등록에 성공했습니다.");
+  } catch (err) {
+    return handleError(err as AxiosError);
+  }
 };
 
 // 게시글 상세 조회
 export const getArticle = async (articleId: number) => {
   try {
     const res = await proxy.get(`/api/articles/${articleId}`);
-    return res.data;
+    return handleSuccess(res, "게시글 상세 조회에 성공했습니다.");
   } catch (err) {
-    const axiosError = err as AxiosError;
-    if (axiosError.response) {
-      return {
-        ok: false,
-        status: axiosError.response.status,
-        message: axiosError.response.statusText,
-      };
-    } else {
-      return {
-        ok: false,
-        status: 500,
-        message: "서버에 연결할 수 없습니다.",
-      };
-    }
+    return handleError(err as AxiosError);
   }
 };
 
 // 게시글 수정
 export const patchArticle = async (query: patchArticleProps) => {
-  const res = await proxy.patch(`/api/articles/${query.articleId}`, query.body);
-  if (res.status === 200) return res.data;
-  else return null;
+  try {
+    const res = await proxy.patch(
+      `/api/articles/${query.articleId}`,
+      query.body
+    );
+    return handleSuccess(res, "게시글 수정에 성공했습니다.");
+  } catch (err) {
+    return handleError(err as AxiosError);
+  }
 };
 
 // 게시글 삭제
 export const deleteArticle = async (articleId: number) => {
-  const res = await proxy.delete(`/api/articles/${articleId}`);
-  if (res.status === 200) return res.data;
-  else return null;
+  try {
+    const res = await proxy.delete(`/api/articles/${articleId}`);
+    return handleSuccess(res, "게시글 삭제에 성공했습니다.");
+  } catch (err) {
+    return handleError(err as AxiosError);
+  }
 };
 
 // 게시글 좋아요 추가
 export const postArticleLike = async (articleId: number) => {
-  const res = await proxy.post(`/api/like/${articleId}`);
-  if (res.status >= 200 && res.status < 300) return res.data;
-  else return {};
+  try {
+    const res = await proxy.post(`/api/like/${articleId}`);
+    return handleSuccess(res, "게시글 좋아요 추가에 성공했습니다.");
+  } catch (err) {
+    return handleError(err as AxiosError);
+  }
 };
 
 // 게시글 좋아요 취소
 export const deleteArticleLike = async (articleId: number) => {
-  const res = await proxy.delete(`/api/like/${articleId}`);
-  if (res.status >= 200 && res.status < 300) return res.data;
-  else return {};
+  try {
+    const res = await proxy.delete(`/api/like/${articleId}`);
+    return handleSuccess(res, "게시글 좋아요 취소에 성공했습니다.");
+  } catch (err) {
+    return handleError(err as AxiosError);
+  }
 };

--- a/src/api/article.ts
+++ b/src/api/article.ts
@@ -1,5 +1,5 @@
+import { instance, proxy } from "./axios";
 import { AxiosError } from "axios";
-import instance, { proxy } from "./axios";
 import handleError from "@/api/handleError";
 import handleSuccess from "@/api/handleSuccess";
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,4 +1,7 @@
-import instance, { proxy } from "./axios";
+import { AxiosError } from "axios";
+import { instance, proxy } from "./axios";
+import handleSuccess from "@/api/handleSuccess";
+import handleError from "@/api/handleError";
 
 interface PostSignUpQuery {
   email: string;
@@ -14,12 +17,20 @@ interface PostSignInQuery {
 
 // 회원가입
 export const postSignUp = async (body: PostSignUpQuery) => {
-  const res = await instance.post(`/auth/signUp`, body);
-  return res.data;
+  try {
+    const res = await instance.post(`/auth/signUp`, body);
+    return handleSuccess(res, "회원가입에 성공했습니다.");
+  } catch (err) {
+    handleError(err as AxiosError);
+  }
 }; //예외처리를 singUp 페이지에서 하고, 에러 메세지를 처리함
 
 // 로그인
 export const postSignIn = async (body: PostSignInQuery) => {
-  const res = await proxy.post(`/api/signIn`, body);
-  if (res.status >= 200 && res.status < 300) return res.data;
+  try {
+    const res = await proxy.post(`/api/signIn`, body);
+    return handleSuccess(res);
+  } catch (err) {
+    return handleError(err as AxiosError);
+  }
 };

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -21,7 +21,7 @@ export const postSignUp = async (body: PostSignUpQuery) => {
     const res = await instance.post(`/auth/signUp`, body);
     return handleSuccess(res, "회원가입에 성공했습니다.");
   } catch (err) {
-    handleError(err as AxiosError);
+    return handleError(err as AxiosError);
   }
 }; //예외처리를 singUp 페이지에서 하고, 에러 메세지를 처리함
 

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from "axios";
 
-const instance = axios.create({
+export const instance = axios.create({
   baseURL: "https://wikied-api.vercel.app/9-3/",
 });
 
@@ -45,5 +45,3 @@ const setupInterceptors = (instance: AxiosInstance) => {
 
 setupInterceptors(instance);
 setupInterceptors(proxy);
-
-export default instance;

--- a/src/api/comment.ts
+++ b/src/api/comment.ts
@@ -1,4 +1,7 @@
-import instance, { proxy } from "./axios";
+import { instance, proxy } from "./axios";
+import { AxiosError } from "axios";
+import handleSuccess from "@/api/handleSuccess";
+import handleError from "@/api/handleError";
 
 interface PostCommentQuery {
   articleId: number;
@@ -18,30 +21,44 @@ interface PatchCommentQuery {
 export const getComments = async (articleId: number) => {
   try {
     const res = await instance.get(`/articles/${articleId}/comments?limit=7`);
-    return res.data.list;
+    return handleSuccess(res, "댓글 목록 조회에 성공했습니다.");
   } catch (err) {
-    console.error("댓글 목록을 불러오지 못했습니다.", err);
-    return [];
+    return handleError(err as AxiosError);
   }
 };
 
 // 댓글 등록
 export const postComment = async (query: PostCommentQuery) => {
-  const res = await proxy.post(`/api/articles/${query.articleId}`, query.body);
-  if (res.status >= 200 && res.status < 300) return res.data;
-  else return {};
+  try {
+    const res = await proxy.post(
+      `/api/articles/${query.articleId}`,
+      query.body
+    );
+    return handleSuccess(res, "댓글 등록에 성공했습니다.");
+  } catch (err) {
+    return handleError(err as AxiosError);
+  }
 };
 
 // 댓글 수정
 export const patchComment = async (query: PatchCommentQuery) => {
-  const res = await proxy.patch(`/api/comments/${query.commentId}`, query.body);
-  if (res.status >= 200 && res.status < 300) return res.data;
-  else return {};
+  try {
+    const res = await proxy.patch(
+      `/api/comments/${query.commentId}`,
+      query.body
+    );
+    return handleSuccess(res);
+  } catch (err) {
+    return handleError(err as AxiosError);
+  }
 };
 
 // 댓글 삭제
 export const deleteComment = async (targetId: number) => {
-  const res = await proxy.delete(`/api/comments/${targetId}`);
-  if (res.status >= 200 && res.status < 300) return res.data;
-  else return {};
+  try {
+    const res = await proxy.delete(`/api/comments/${targetId}`);
+    return handleSuccess(res, "댓글 삭제에 성공했습니다.");
+  } catch (err) {
+    return handleError(err as AxiosError);
+  }
 };

--- a/src/api/handleError.ts
+++ b/src/api/handleError.ts
@@ -1,0 +1,13 @@
+import { AxiosError } from "axios";
+
+const handleError = (err: AxiosError) => {
+  console.log("api 함수를 불러오던 도중 오류가 발생했습니다.", err);
+
+  return {
+    ok: false,
+    status: err.response?.status || 500,
+    message: err.response?.statusText || "서버에 오류가 발생했습니다.",
+  };
+};
+
+export default handleError;

--- a/src/api/handleSuccess.ts
+++ b/src/api/handleSuccess.ts
@@ -1,0 +1,11 @@
+import { AxiosResponse } from "axios";
+
+const handleSuccess = (res: AxiosResponse, message: string) => {
+  return {
+    ok: true,
+    data: res.data,
+    message: message,
+  };
+};
+
+export default handleSuccess;

--- a/src/api/handleSuccess.ts
+++ b/src/api/handleSuccess.ts
@@ -1,10 +1,10 @@
 import { AxiosResponse } from "axios";
 
-const handleSuccess = (res: AxiosResponse, message: string) => {
+const handleSuccess = (res: AxiosResponse, message?: string) => {
   return {
     ok: true,
     data: res.data,
-    message: message,
+    message: res.data.message || message,
   };
 };
 

--- a/src/api/image.ts
+++ b/src/api/image.ts
@@ -1,4 +1,4 @@
-import instance, { proxy } from "./axios";
+import { instance, proxy } from "./axios";
 
 // 이미지 업로드
 export const postImage = async (data: FormData) => {

--- a/src/api/notification.ts
+++ b/src/api/notification.ts
@@ -1,15 +1,24 @@
 import { proxy } from "./axios";
+import { AxiosError } from "axios";
+import handleSuccess from "@/api/handleSuccess";
+import handleError from "@/api/handleError";
 
 // 알림 목록 조회
 export const getNotifications = async () => {
-  const res = await proxy.get(`/api/notifications/`);
-  if (res.status >= 200 && res.status < 300) return res.data;
-  else return [];
+  try {
+    const res = await proxy.get(`/api/notifications/`);
+    return handleSuccess(res);
+  } catch (err) {
+    return handleError(err as AxiosError);
+  }
 };
 
 // 알림 삭제
 export const deleteNotifications = async (id: number) => {
-  const res = await proxy.delete(`/api/notifications/${id}`);
-  if (res.status >= 200 && res.status < 300) return res.data;
-  else return {};
+  try {
+    const res = await proxy.delete(`/api/notifications/${id}`);
+    return handleSuccess(res);
+  } catch (err) {
+    return handleError(err as AxiosError);
+  }
 };

--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -1,5 +1,8 @@
-import instance, { proxy } from "@/api/axios";
+import { Axios, AxiosError } from "axios";
+import { instance, proxy } from "@/api/axios";
 import { PatchBody } from "@/types/types";
+import handleError from "@/api/handleError";
+import handleSuccess from "@/api/handleSuccess";
 
 interface GetProfilesQuery {
   page?: number;
@@ -33,10 +36,9 @@ export const getProfiles = async (query: GetProfilesQuery = {}) => {
   try {
     const res = await instance.get(`${baseUrl}${queryString}`);
 
-    return res.data.list;
+    return handleSuccess(res, "프로필 목록 조회에 성공했습니다.");
   } catch (err) {
-    console.error("프로필 정보들을 불러오지 못했습니다.", err);
-    return [];
+    return handleError(err as AxiosError);
   }
 };
 
@@ -51,10 +53,12 @@ export const getProfilesByName = async (query: GetProfilesQuery = {}) => {
     const res = await instance.get(`${baseUrl}${queryString}`);
 
     // 이름 검색과 관련한 api 요청은 totalCount도 받아야 하기 때문에 data까지만 return
-    return res.data;
+    return handleSuccess(
+      res,
+      "해당하는 이름의 프로필을 조회하는데 성공했습니다."
+    );
   } catch (err) {
-    console.error("프로필 정보들을 불러오지 못했습니다.", err);
-    return [];
+    return handleError(err as AxiosError);
   }
 };
 
@@ -62,36 +66,41 @@ export const getProfilesByName = async (query: GetProfilesQuery = {}) => {
 export const getUserProfile = async (code: string) => {
   try {
     const res = await instance.get(`/profiles/${code}`);
-    return res;
+    return handleSuccess(res, "사용자 프로필 조회에 성공했습니다.");
   } catch (err) {
-    console.error("프로필 정보들을 불러오지 못했습니다.", err);
-    return;
+    return handleError(err as AxiosError);
   }
 };
 
 export const patchProfile = async (query: PatchProfileQuery) => {
   const { code, body } = query;
-  const res = await proxy.patch(`/api/profiles/${code}`, body);
-  if (res.status >= 200 && res.status < 300) return res.data;
-  else return {};
+
+  try {
+    const res = await proxy.patch(`/api/profiles/${code}`, body);
+    return handleSuccess(res);
+  } catch (err) {
+    return handleError(err as AxiosError);
+  }
 };
 
 // 프로필 수정 중 체크
 export const getProfilePing = async (code: string) => {
   try {
     const res = await instance.get(`/profiles/${code}/ping`);
-    return res;
+    return handleSuccess(res, "프로필 수정중 확인 요청에 성공했습니다.");
   } catch (err) {
-    console.error("프로필 핑 요청 중 에러 발생: ", err);
-    return;
+    return handleError(err as AxiosError);
   }
 };
 
 // 프로필 생성
 export const postProfile = async (body: PostProfileQuery) => {
-  const res = await proxy.post(`/api/profiles`, body);
-  if (res.status >= 200 && res.status < 300) return res.data;
-  else return {};
+  try {
+    const res = await proxy.post(`/api/profiles`, body);
+    return handleSuccess(res);
+  } catch (err) {
+    return handleError(err as AxiosError);
+  }
 };
 
 // 프로필 수정 중 갱신
@@ -99,7 +108,10 @@ export const postProfilePing = async (
   content: PostProfilePingQuery,
   code: string
 ) => {
-  const res = await proxy.post(`/api/profiles/${code}`, content);
-  if (res.status >= 200 && res.status < 300) return res.data;
-  else return {};
+  try {
+    const res = await proxy.post(`/api/profiles/${code}`, content);
+    return handleSuccess(res);
+  } catch (err) {
+    handleError(err as AxiosError);
+  }
 };

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,4 +1,7 @@
 import { proxy } from "./axios";
+import { AxiosError } from "axios";
+import handleSuccess from "@/api/handleSuccess";
+import handleError from "@/api/handleError";
 
 export interface PatchUserQuery {
   passwordConfirmation: string;
@@ -8,14 +11,20 @@ export interface PatchUserQuery {
 
 // 유저 정보를 받아오는 함수
 export const getUser = async () => {
-  const res = await proxy.get(`/api/user`);
-  if (res.status >= 200 && res.status < 300) return res.data;
-  else return {};
+  try {
+    const res = await proxy.get(`/api/user`);
+    return handleSuccess(res);
+  } catch (err) {
+    return handleError(err as AxiosError);
+  }
 };
 
 // 새로운 비밀번호와 현재 비밀번호를 data로 받아서 변경하는 함수
 export const patchUser = async (body: PatchUserQuery) => {
-  const res = await proxy.patch(`/api/user`, body);
-  if (res.status >= 200 && res.status < 300) return res.data;
-  else return {};
+  try {
+    const res = await proxy.patch(`/api/user`, body);
+    return handleSuccess(res);
+  } catch (err) {
+    return handleError(err as AxiosError);
+  }
 };

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -6,7 +6,7 @@ const ServerError = () => {
     <main className="flex justify-center items-center h-screen">
       <div className="flex flex-col mb-44 w-[1200px] h-[250px]">
         <h2 className="font-bold text-[#3ecfad] text-[80px]">
-          500 Internal Server Error
+          500 Server Error
         </h2>
         <p className="mt-4 text-gray-400">
           서버에 문제가 발생했습니다.

--- a/src/pages/api/articles/[articleId].ts
+++ b/src/pages/api/articles/[articleId].ts
@@ -2,18 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { parse } from "cookie";
 import { AxiosError } from "axios";
 import instance from "@/api/axios";
-
-const handleError = (
-  res: NextApiResponse,
-  err: AxiosError,
-  defaultMessage: string
-) => {
-  console.error(`Error occurred: ${err.message}`);
-  return res.status(err.response?.status || 500).json({
-    ok: false,
-    message: err.response?.statusText || defaultMessage,
-  });
-};
+import handleError from "@/pages/api/handleError";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookies = parse(req.headers.cookie || "");

--- a/src/pages/api/articles/[articleId].ts
+++ b/src/pages/api/articles/[articleId].ts
@@ -3,17 +3,18 @@ import { parse } from "cookie";
 import { AxiosError } from "axios";
 import instance from "@/api/axios";
 import handleError from "@/pages/api/handleError";
+import handleSuccess from "@/pages/api/handleSuccess";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookies = parse(req.headers.cookie || "");
   const accessToken = cookies.accessToken;
 
-  const { articleId } = req.query;
+  const articleId = req.query.id;
   if (!articleId) {
     return res.status(400).json({
       ok: false,
       data: null,
-      message: "게시글 ID를 찾지 못했습니다.",
+      message: "유효하지 않은 게시글 ID입니다.",
     });
   }
 
@@ -23,11 +24,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         const response = await instance.get(`/articles/${articleId}`, {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
-        return res.status(200).json({
-          ok: true,
-          data: response.data,
-          message: "게시글 조회에 성공했습니다.",
-        });
+        return handleSuccess(res, response.data, "게시글 조회에 성공했습니다");
       } catch (err) {
         return handleError(
           res,
@@ -45,11 +42,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
             headers: { Authorization: `Bearer ${accessToken}` },
           }
         );
-        return res.status(201).json({
-          ok: true,
-          data: response.data,
-          message: "댓글 등록에 성공했습니다.",
-        });
+        return handleSuccess(res, response.data, "댓글 등록에 성공했습니다");
       } catch (err) {
         return handleError(
           res,
@@ -67,11 +60,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
             headers: { Authorization: `Bearer ${accessToken}` },
           }
         );
-        return res.status(200).json({
-          ok: true,
-          data: response.data,
-          message: "게시글 수정에 성공하였습니다.",
-        });
+        return handleSuccess(res, response.data, "게시글 수정에 성공했습니다");
       } catch (err) {
         return handleError(
           res,
@@ -85,11 +74,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         const response = await instance.delete(`/articles/${articleId}`, {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
-        return res.status(200).json({
-          ok: true,
-          data: response.data,
-          message: "게시글 삭제에 성공했습니다.",
-        });
+        return handleSuccess(res, response.data, "게시글 삭제에 성공했습니다");
       } catch (err) {
         return handleError(
           res,

--- a/src/pages/api/articles/index.ts
+++ b/src/pages/api/articles/index.ts
@@ -1,17 +1,12 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { parse } from "cookie";
+import { AxiosError } from "axios";
 import instance from "@/api/axios";
+import handleError from "@/pages/api/handleError";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookies = parse(req.headers.cookie || "");
   const accessToken = cookies.accessToken;
-
-  // const { articleId } = req.query;
-  // if (!articleId) {
-  //   return res
-  //     .status(400)
-  //     .json({ message: "쿼리 파라미터에 게시글 ID가 없습니다." });
-  // }
 
   switch (req.method) {
     case "POST":
@@ -20,10 +15,17 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         const response = await instance.post("/articles", req.body, {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
-        return res.status(201).json(response.data);
+        return res.status(201).json({
+          ok: true,
+          data: response.data,
+          message: "게시글 등록에 성공했습니다.",
+        });
       } catch (err) {
-        console.error(err);
-        return res.status(500).json({ message: "게시글 등록에 실패했습니다." });
+        return handleError(
+          res,
+          err as AxiosError,
+          "게시글 등록에 실패했습니다."
+        );
       }
 
     default:

--- a/src/pages/api/articles/index.ts
+++ b/src/pages/api/articles/index.ts
@@ -3,6 +3,7 @@ import { parse } from "cookie";
 import { AxiosError } from "axios";
 import instance from "@/api/axios";
 import handleError from "@/pages/api/handleError";
+import handleSuccess from "@/pages/api/handleSuccess";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookies = parse(req.headers.cookie || "");
@@ -15,16 +16,12 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         const response = await instance.post("/articles", req.body, {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
-        return res.status(201).json({
-          ok: true,
-          data: response.data,
-          message: "게시글 등록에 성공했습니다.",
-        });
+        return handleSuccess(res, response.data, "게시글 등록에 성공했습니다");
       } catch (err) {
         return handleError(
           res,
           err as AxiosError,
-          "게시글 등록에 실패했습니다."
+          "게시글 등록 중 오류가 발생했습니다."
         );
       }
 

--- a/src/pages/api/comments/[commentId].ts
+++ b/src/pages/api/comments/[commentId].ts
@@ -1,6 +1,9 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { parse } from "cookie";
+import { AxiosError } from "axios";
 import instance from "@/api/axios";
+import handleError from "@/pages/api/handleError";
+import handleSuccess from "@/pages/api/handleSuccess";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookies = parse(req.headers.cookie || "");
@@ -9,7 +12,11 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const { commentId } = req.query;
   if (!commentId)
     if (!commentId) {
-      return res.status(400).json({ message: "수정할 댓글 ID가 없습니다." });
+      return res.status(400).json({
+        ok: false,
+        data: null,
+        message: "유효하지 않은 댓글 id입니다.",
+      });
     }
 
   switch (req.method) {
@@ -23,10 +30,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
             headers: { Authorization: `Bearer ${accessToken}` },
           }
         );
-        return res.status(201).json(response.data);
+        return handleSuccess(res, response.data, "댓글 수정에 성공했습니다");
       } catch (err) {
-        console.error(err);
-        return res.status(500).json({ message: "댓글 수정에 실패했습니다." });
+        return handleError(
+          res,
+          err as AxiosError,
+          "댓글 수정 중 오류가 발생했습니다."
+        );
       }
 
     case "DELETE":
@@ -34,10 +44,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         const response = await instance.delete(`/comments/${commentId}`, {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
-        return res.status(200).json(response.data);
+        return handleSuccess(res, response.data, "댓글 삭제에 성공했습니다");
       } catch (err) {
-        console.error(err);
-        return res.status(500).json({ message: "댓글 삭제에 실패했습니다." });
+        return handleError(
+          res,
+          err as AxiosError,
+          "댓글 삭제 중 오류가 발생했습니다."
+        );
       }
 
     default:

--- a/src/pages/api/comments/index.ts
+++ b/src/pages/api/comments/index.ts
@@ -1,6 +1,9 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { parse } from "cookie";
 import instance from "@/api/axios";
+import handleError from "@/pages/api/handleError";
+import { AxiosError } from "axios";
+import handleSuccess from "@/pages/api/handleSuccess";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookies = parse(req.headers.cookie || "");
@@ -10,12 +13,14 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     case "POST":
       // 댓글 등록 로직
       const articleId = req.query.id;
-      if (!articleId)
-        if (!articleId) {
-          return res
-            .status(400)
-            .json({ message: "댓글을 등록할 게시글 ID가 없습니다." });
-        }
+      if (!articleId) {
+        return res.status(400).json({
+          ok: false,
+          data: null,
+          message: "유효하지 않은 게시글 ID입니다.",
+        });
+      }
+
       try {
         const response = await instance.post(
           `/articles/${articleId}/comments`,
@@ -24,48 +29,59 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
             headers: { Authorization: `Bearer ${accessToken}` },
           }
         );
-        return res.status(201).json(response.data);
+        return handleSuccess(res, response.data, "댓글 등록에 성공했습니다");
       } catch (err) {
-        console.error(err);
-        return res.status(500).json({ message: "게시글 등록에 실패했습니다." });
+        return handleError(res, err as AxiosError, "댓글 등록에 실패했습니다.");
       }
 
     case "PATCH":
       // 댓글 등록 로직
-      const { commentId: patchComment } = req.query;
-      if (!patchComment)
-        if (!patchComment) {
-          return res
-            .status(400)
-            .json({ message: "수정할 댓글 ID가 없습니다." });
+      const commentId = req.query.commentId;
+      if (!commentId)
+        if (!commentId) {
+          return res.status(400).json({
+            ok: true,
+            data: null,
+            message: "유효하지 않은 댓글 ID입니다.",
+          });
         }
       try {
         const response = await instance.patch(
-          `/articles/comments/${patchComment}`,
+          `/articles/comments/${commentId}`,
           req.body.content,
           {
             headers: { Authorization: `Bearer ${accessToken}` },
           }
         );
-        return res.status(201).json(response.data);
+        return handleSuccess(res, response.data, "댓글 수정에 성공했습니다");
       } catch (err) {
-        console.error(err);
-        return res.status(500).json({ message: "댓글 수정에 실패했습니다." });
+        return handleError(
+          res,
+          err as AxiosError,
+          "댓글 수정 중 오류가 발생했습니다."
+        );
       }
 
     case "DELETE":
-      const { commentId: deleteComment } = req.query;
-      if (!deleteComment) {
-        return res.status(400).json({ message: "삭제할 댓글 ID가 없습니다." });
+      const { commentId: deleteId } = req.query;
+      if (!deleteId) {
+        return res.status(400).json({
+          ok: true,
+          data: null,
+          message: "유효하지 않은 댓글 ID입니다.",
+        });
       }
       try {
-        const response = await instance.delete(`/comments/${deleteComment}`, {
+        const response = await instance.delete(`/comments/${deleteId}`, {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
-        return res.status(200).json(response.data);
+        return handleSuccess(res, response.data, "댓글 삭제에 성공했습니다");
       } catch (err) {
-        console.error(err);
-        return res.status(500).json({ message: "댓글 삭제에 실패했습니다." });
+        return handleError(
+          res,
+          err as AxiosError,
+          "댓글 삭제 중 오류가 발생했습니다."
+        );
       }
 
     default:

--- a/src/pages/api/handleError.ts
+++ b/src/pages/api/handleError.ts
@@ -1,0 +1,17 @@
+import { AxiosError } from "axios";
+import { NextApiResponse } from "next";
+
+const handleError = (
+  res: NextApiResponse,
+  err: AxiosError,
+  defaultMessage: string
+) => {
+  console.error(`API Route Error occurred: ${err.message}`);
+  return res.status(err.response?.status || 500).json({
+    ok: false,
+    data: null,
+    message: err.response?.statusText || defaultMessage,
+  });
+};
+
+export default handleError;

--- a/src/pages/api/handleError.ts
+++ b/src/pages/api/handleError.ts
@@ -9,7 +9,7 @@ const handleError = (
   console.error(`API Route Error occurred: ${err.message}`);
   return res.status(err.response?.status || 500).json({
     ok: false,
-    data: null,
+    data: err.response?.data,
     message: err.response?.statusText || defaultMessage,
   });
 };

--- a/src/pages/api/handleSuccess.ts
+++ b/src/pages/api/handleSuccess.ts
@@ -1,0 +1,16 @@
+import { NextApiResponse } from "next";
+
+const handleSuccess = (
+  res: NextApiResponse,
+  data: any,
+  message: string,
+  statusCode: number = 200
+) => {
+  return res.status(statusCode).json({
+    ok: true,
+    data,
+    message,
+  });
+};
+
+export default handleSuccess;

--- a/src/pages/api/like/[articleId].ts
+++ b/src/pages/api/like/[articleId].ts
@@ -1,16 +1,29 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { parse } from "cookie";
+import { AxiosError } from "axios";
 import instance from "@/api/axios";
+import handleSuccess from "@/pages/api/handleSuccess";
+import handleError from "@/pages/api/handleError";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookies = parse(req.headers.cookie || "");
   const accessToken = cookies.accessToken;
-
   const { articleId } = req.query;
+
+  if (!accessToken) {
+    return res.status(400).json({
+      ok: false,
+      data: null,
+      message: "accessToken을 찾지 못했습니다.",
+    });
+  }
+
   if (!articleId) {
-    return res
-      .status(400)
-      .json({ message: "좋아요를 등록할 게시글 ID가 없습니다." });
+    return res.status(400).json({
+      ok: false,
+      data: null,
+      message: "유효하지 않은 게시글 ID입니다.",
+    });
   }
 
   switch (req.method) {
@@ -24,12 +37,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
             headers: { Authorization: `Bearer ${accessToken}` },
           }
         );
-        return res.status(201).json(response.data);
+        return handleSuccess(res, response.data, "좋아요 등록에 성공했습니다.");
       } catch (err) {
-        console.error(err);
-        return res
-          .status(500)
-          .json({ message: "게시글 좋아요 등록에 실패했습니다." });
+        return handleError(
+          res,
+          err as AxiosError,
+          "좋아요 등록 중 오류가 발생했습니다."
+        );
       }
 
     case "DELETE":
@@ -38,12 +52,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         const response = await instance.delete(`/articles/${articleId}/like`, {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
-        return res.status(200).json(response.data);
+        return handleSuccess(res, response.data, "좋아요 취소에 성공했습니다.");
       } catch (err) {
-        console.error(err);
-        return res
-          .status(500)
-          .json({ message: "게시글 좋아요 취소에 실패했습니다." });
+        return handleSuccess(
+          res,
+          err as AxiosError,
+          "좋아요 취소 중 오류가 발생했습니다."
+        );
       }
 
     default:

--- a/src/pages/api/like/[articleId].ts
+++ b/src/pages/api/like/[articleId].ts
@@ -14,7 +14,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     return res.status(400).json({
       ok: false,
       data: null,
-      message: "accessToken을 찾지 못했습니다.",
+      message: "accessToken이 존재하지 않습니다.",
     });
   }
 

--- a/src/pages/api/notifications/[id].ts
+++ b/src/pages/api/notifications/[id].ts
@@ -1,6 +1,9 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { parse } from "cookie";
+import { AxiosError } from "axios";
 import instance from "@/api/axios";
+import handleSuccess from "@/pages/api/handleSuccess";
+import handleError from "@/pages/api/handleError";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookies = parse(req.headers.cookie || "");
@@ -8,7 +11,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
   const { id } = req.query;
   if (!id) {
-    return res.status(400).json({ message: "삭제할 알림 ID가 없습니다." });
+    return res
+      .status(400)
+      .json({ ok: false, data: null, message: "유효하지 않은 알림 ID입니다." });
   }
 
   switch (req.method) {
@@ -18,10 +23,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         const response = await instance.delete(`/notifications/${id}`, {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
-        return res.status(200).json(response.data);
+        return handleSuccess(res, response.data, "알림 삭제에 성공했습니다.");
       } catch (err) {
-        console.error(err);
-        return res.status(500).json({ message: "알림 삭제에 실패했습니다." });
+        return handleError(
+          res,
+          err as AxiosError,
+          "알림 삭제 중 오류가 발생했습니다."
+        );
       }
 
     default:

--- a/src/pages/api/notifications/index.ts
+++ b/src/pages/api/notifications/index.ts
@@ -1,10 +1,21 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { parse } from "cookie";
+import { AxiosError } from "axios";
 import instance from "@/api/axios";
+import handleSuccess from "@/pages/api/handleSuccess";
+import handleError from "@/pages/api/handleError";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookies = parse(req.headers.cookie || "");
   const accessToken = cookies.accessToken;
+
+  if (!accessToken) {
+    return res.status(400).json({
+      ok: false,
+      data: null,
+      mesage: "accessToken이 존재하지 않습니다.",
+    });
+  }
 
   switch (req.method) {
     case "GET":
@@ -16,12 +27,17 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
             headers: { Authorization: `Bearer ${accessToken}` },
           }
         );
-        return res.status(201).json(response.data);
+        return handleSuccess(
+          res,
+          response.data,
+          "알림목록 조회에 성공했습니다."
+        );
       } catch (err) {
-        console.error(err);
-        return res
-          .status(500)
-          .json({ message: "알림 목록 조회에 실패했습니다." });
+        handleError(
+          res,
+          err as AxiosError,
+          "알림목록 조회 중 오류가 발생했습니다."
+        );
       }
     default:
       res.setHeader("Allow", ["GET"]);

--- a/src/pages/api/profiles/[code].ts
+++ b/src/pages/api/profiles/[code].ts
@@ -1,6 +1,9 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { parse } from "cookie";
+import { AxiosError } from "axios";
 import instance from "@/api/axios";
+import handleSuccess from "@/pages/api/handleSuccess";
+import handleError from "@/pages/api/handleError";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookies = parse(req.headers.cookie || "");
@@ -8,7 +11,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
   const { code } = req.query;
   if (!code) {
-    return res.status(400).json({ message: "수정할 프로필 code가 없습니다." });
+    return res
+      .status(400)
+      .json({ message: "유효하지 않은 프로필 CODE입니다." });
   }
 
   switch (req.method) {
@@ -18,12 +23,16 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         const response = await instance.patch(`/profiles/${code}`, req.body, {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
-        return res.status(200).json(response.data);
+        return handleSuccess(res, response.data, "프로필 수정에 성공했습니다.");
       } catch (err) {
-        return res.status(500).json({ message: "프로필 수정에 실패했습니다." });
+        return handleError(
+          res,
+          err as AxiosError,
+          "프로필 수정 중 오류가 발생했습니다."
+        );
       }
     case "POST":
-      // 프로필 수정 중 갱신 로직
+      // 프로필 수정시간 갱신 로직
       try {
         const response = await instance.post(
           `/profiles/${code}/ping`,
@@ -32,11 +41,17 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
             headers: { Authorization: `Bearer ${accessToken}` },
           }
         );
-        return res.status(201).json(response.data);
+        return handleSuccess(
+          res,
+          response.data,
+          "프로필 수정시간 갱신에 성공했습니다."
+        );
       } catch (err) {
-        return res
-          .status(500)
-          .json({ message: "프로필 수정 중 갱신에 실패했습니다." });
+        return handleError(
+          res,
+          err as AxiosError,
+          "프로필 수정시간 갱신 중 오류가 발생했습니다."
+        );
       }
 
     default:

--- a/src/pages/api/refresh-token.ts
+++ b/src/pages/api/refresh-token.ts
@@ -3,12 +3,17 @@ import { parse, serialize } from "cookie";
 import { AxiosError } from "axios";
 import instance from "@/api/axios";
 import handleError from "@/pages/api/handleError";
+import handleSuccess from "@/pages/api/handleSuccess";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookies = parse(req.headers.cookie || "");
   const refreshToken = cookies.refreshToken;
   if (!refreshToken) {
-    return res.status(400).json({ message: "리프레시 토큰이 없습니다." });
+    return res.status(400).json({
+      ok: false,
+      data: null,
+      message: "refreshToken이 존재하지 않습니다.",
+    });
   }
 
   switch (req.method) {
@@ -34,16 +39,16 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         );
 
         // 성공 응답
-        return res.status(200).json({
-          ok: true,
-          data: response.data.accessToken,
-          message: "액세스 토큰이 갱신되었습니다.",
-        });
+        return handleSuccess(
+          res,
+          response.data,
+          "accessToken 갱신에 성공했습니다."
+        );
       } catch (err) {
         handleError(
           res,
           err as AxiosError,
-          "액세스 토큰 재갱신에 실패하였습니다."
+          "accessToken 갱신 중 오류가 발생했습니다."
         );
       }
     default:

--- a/src/pages/api/refresh-token.ts
+++ b/src/pages/api/refresh-token.ts
@@ -1,6 +1,8 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { parse, serialize } from "cookie";
+import { AxiosError } from "axios";
 import instance from "@/api/axios";
+import handleError from "@/pages/api/handleError";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookies = parse(req.headers.cookie || "");
@@ -33,14 +35,16 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
         // 성공 응답
         return res.status(200).json({
+          ok: true,
+          data: response.data.accessToken,
           message: "액세스 토큰이 갱신되었습니다.",
-          accessToken: newAccessToken,
         });
       } catch (err) {
-        console.error(err);
-        return res
-          .status(500)
-          .json({ message: "액세스 토큰 갱신에 실패했습니다." });
+        handleError(
+          res,
+          err as AxiosError,
+          "액세스 토큰 재갱신에 실패하였습니다."
+        );
       }
     default:
       res.setHeader("Allow", ["POST"]);

--- a/src/pages/api/signIn.ts
+++ b/src/pages/api/signIn.ts
@@ -3,6 +3,7 @@ import { serialize } from "cookie";
 import { AxiosError } from "axios";
 import instance from "@/api/axios";
 import handleError from "@/pages/api/handleError";
+import handleSuccess from "@/pages/api/handleSuccess";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method === "POST") {
@@ -31,13 +32,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         }),
       ]);
 
-      res.status(200).json({
-        ok: true,
-        message: "로그인 성공",
-        user: userData,
-      });
+      return handleSuccess(res, userData, "로그인에 성공했습니다.");
     } catch (err) {
-      handleError(res, err as AxiosError, "로그인에 실패했습니다.");
+      handleError(res, err as AxiosError, "로그인 중 오류가 발생했습니다.");
     }
   } else {
     res.setHeader("Allow", ["POST"]);

--- a/src/pages/api/signIn.ts
+++ b/src/pages/api/signIn.ts
@@ -1,47 +1,43 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { serialize } from "cookie";
+import { AxiosError } from "axios";
 import instance from "@/api/axios";
-import { Axios, AxiosError } from "axios";
+import handleError from "@/pages/api/handleError";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method === "POST") {
     try {
       const response = await instance.post("/auth/signIn", req.body);
 
-      if (response.status !== 200) {
-        throw new Error("네트워크 응답이 좋지 않습니다.");
-      }
-
-      const data = response.data; // 응답 데이터
+      const accessToken = response.data.accessToken;
+      const refreshToken = response.data.refreshToken;
+      const userData = response.data.user;
 
       // accessToken과 refreshToken을 쿠키에 저장
       res.setHeader("Set-Cookie", [
-        serialize("accessToken", data.accessToken, {
-          httpOnly: true, // 스크립트로 쿠키에 접근하지 못하게 함. -> XXS 공격을 보완, 허나 클라이언트에서 쿠키를 set,get 하지 못하게 됨. -> 서버에서 관리가 필요.
-          secure: process.env.NODE_ENV === "production", // 프로덕션 환경에서만 secure 옵션 사용, HTTP 연결에서도 쿠키를 전송할 수 있는 편의 제공.
-          sameSite: "strict",
-          maxAge: 60 * 60, // 생명 1시간
+        serialize("accessToken", accessToken, {
+          httpOnly: true, // 브라우저에서 악성 스크립트로 쿠키에 접근 불가 -> XXS 공격을 보완
+          secure: process.env.NODE_ENV === "production", // 프로덕션 환경에서만 secure 옵션 사용, 개발자 환경에서는 HTTP 연결에서도 쿠키를 전송할 수 있는 편의 제공.
+          sameSite: "strict", // 같은 도메인끼리만 쿠키를 주고받을 수 있음 -> CSRF 보완
+          maxAge: 60 * 60, // 쿠키의 생명력 1시간
           path: "/",
         }),
-        serialize("refreshToken", data.refreshToken, {
+        serialize("refreshToken", refreshToken, {
           httpOnly: true,
           secure: process.env.NODE_ENV === "production",
           sameSite: "strict",
-          maxAge: 60 * 60 * 24 * 30, // 생명 30일
+          maxAge: 60 * 60 * 24 * 30,
           path: "/",
         }),
       ]);
 
       res.status(200).json({
+        ok: true,
         message: "로그인 성공",
-        user: data.user,
+        user: userData,
       });
-    } catch (error) {
-      if (error instanceof AxiosError) {
-        const errorMessage = error.response?.data.message;
-        // (error as Error).message || "알 수 없는 오류가 발생했습니다.";
-        res.status(500).json({ message: errorMessage, user: null });
-      }
+    } catch (err) {
+      handleError(res, err as AxiosError, "로그인에 실패했습니다.");
     }
   } else {
     res.setHeader("Allow", ["POST"]);

--- a/src/pages/api/user.ts
+++ b/src/pages/api/user.ts
@@ -3,10 +3,18 @@ import { parse } from "cookie";
 import { AxiosError } from "axios";
 import instance from "@/api/axios";
 import handleError from "@/pages/api/handleError";
+import handleSuccess from "@/pages/api/handleSuccess";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookies = parse(req.headers.cookie || "");
   const accessToken = cookies.accessToken;
+
+  if (!accessToken)
+    return res.status(400).json({
+      ok: false,
+      data: null,
+      message: "accessToken이 존재하지 않습니다.",
+    });
 
   switch (req.method) {
     case "GET":
@@ -15,13 +23,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         const response = await instance.get(`/users/me`, {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
-        return res.status(201).json({
-          ok: true,
-          data: response.data,
-          message: "프로필 조회에 성공했습니다.",
-        });
+        return handleSuccess(res, response.data, "프로필 조회에 성공했습니다.");
       } catch (err) {
-        handleError(res, err as AxiosError, "프로필 조회에 실패했습니다.");
+        handleError(
+          res,
+          err as AxiosError,
+          "프로필 조회 중 오류가 발생했습니다."
+        );
       }
 
     case "PATCH":
@@ -30,14 +38,14 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         const response = await instance.patch(`/users/me/password/`, req.body, {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
-        return res.status(201).json({
-          ok: true,
-          data: response.data,
-          message: "비밀번호 수정에 성공했습니다ㅏ.",
-        });
+        handleSuccess(res, response.data, "비밀번호 변경에 성공했습니다.");
       } catch (err) {
         console.error(err);
-        handleError(res, err as AxiosError, "프로필 조회에 실패했습니다.");
+        handleError(
+          res,
+          err as AxiosError,
+          "비밀번호 변경 중 오류가 발생했습니다."
+        );
       }
 
     default:

--- a/src/pages/api/user.ts
+++ b/src/pages/api/user.ts
@@ -1,6 +1,8 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { parse } from "cookie";
+import { AxiosError } from "axios";
 import instance from "@/api/axios";
+import handleError from "@/pages/api/handleError";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookies = parse(req.headers.cookie || "");
@@ -13,10 +15,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         const response = await instance.get(`/users/me`, {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
-        return res.status(201).json(response.data);
+        return res.status(201).json({
+          ok: true,
+          data: response.data,
+          message: "프로필 조회에 성공했습니다.",
+        });
       } catch (err) {
-        console.error(err);
-        return res.status(500).json({ message: "프로필 조회에 실패했습니다." });
+        handleError(res, err as AxiosError, "프로필 조회에 실패했습니다.");
       }
 
     case "PATCH":
@@ -25,12 +30,14 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         const response = await instance.patch(`/users/me/password/`, req.body, {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
-        return res.status(201).json(response.data);
+        return res.status(201).json({
+          ok: true,
+          data: response.data,
+          message: "비밀번호 수정에 성공했습니다ㅏ.",
+        });
       } catch (err) {
         console.error(err);
-        return res
-          .status(500)
-          .json({ message: "비밀번호 수정에 실패했습니다." });
+        handleError(res, err as AxiosError, "프로필 조회에 실패했습니다.");
       }
 
     default:


### PR DESCRIPTION
## 작업 내용
- 모든 API util 함수가 반환하는 타입에 일관성을 넣어주기 위해 handleError와 handleSuccess라는 함수를 호출하게끔 수정했습니다.
- API route 함수 또한 마찬가지입니다.

## 해야 하는 작업
- 기존에 API util 함수에서 return res.data.list로 반환해주던 것들 또한 모두 return handleSuccess(res)로 들어가 반환받는 클라이언트 컴포넌트에서 에러가 날 것입니다. 이를 컴포넌트쪽에서 수정하는 작업이 필요합니다.